### PR TITLE
Docs passing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Local
 pysis/__pycache__
 venv
 pysis.egg-info
+.vscode
+docs/_build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,30 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+    # You can also specify other tool versions:
+    # nodejs: "16"
+    # rust: "1.55"
+    # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PySIS
 
+[![Documentation Status](https://readthedocs.org/projects/pysis-docs/badge/?version=latest)](https://pysis-docs.readthedocs.io/en/latest/?badge=latest)
+
 Abstraction layer over the COM HYSYS interface using Python. Allows for the use of functions without having to step to COM level, which is sometimes esoteric. Maintains the whole functionality of the COM objects, since these are loaded as attributes of the superclass.
 
 As of now, it is checked to work with `Aspen HYSYS V11`. No idea if it works with `Aspen HYSYS V12`.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,48 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'pysis'
+copyright = '2022, Daniel Vázquez Vázquez'
+author = 'Daniel Vázquez Vázquez'
+release = '0.1.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.coverage',
+              'sphinx_rtd_theme',
+]
+
+# templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+# html_static_path = ['_static']
+
+# GitHub integration
+html_context = {
+    "display_github": True, # Integrate GitHub
+    "github_user": "lf-santos", # Username
+    "github_repo": "PySIS", # Repo name
+    "github_version": "master", # Version
+    "conf_py_path": "/docs/", # Path in the checkout to the docs root
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ html_theme = "sphinx_rtd_theme"
 # GitHub integration
 html_context = {
     "display_github": True, # Integrate GitHub
-    "github_user": "lf-santos", # Username
+    "github_user": "DanielVazVaz", # Username
     "github_repo": "PySIS", # Repo name
     "github_version": "master", # Version
     "conf_py_path": "/docs/", # Path in the checkout to the docs root

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+.. pysis documentation master file, created by
+   sphinx-quickstart on Tue Oct 11 23:07:58 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to pysis's documentation!
+=================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   modules

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,7 @@
+PySIS
+=====
+
+.. toctree::
+   :maxdepth: 4
+
+   pysis

--- a/docs/pysis.rst
+++ b/docs/pysis.rst
@@ -1,0 +1,8 @@
+pysis.flowsheet
+----------------------
+
+.. automodule:: pysis.flowsheet
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+pywin32>=225
+Sphinx==5.2.3
+sphinx-rtd-theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,2 @@
-pywin32>=225
 Sphinx==5.2.3
 sphinx-rtd-theme==1.0.0

--- a/pysis/flowsheet.py
+++ b/pysis/flowsheet.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import win32com.client as win32
 import os 
 
 class Simulation:
@@ -10,7 +9,9 @@ class Simulation:
 
         Args:
             path (str): String with the raw path to the HYSYS file. If "Active", chooses the open HYSYS flowsheet.
-        """        
+        """      
+        import win32com.client as win32  
+        
         self.app = win32.Dispatch("HYSYS.Application")
         if path == "Active":
             self.case = self.app.ActiveDocument


### PR DESCRIPTION
Hey Daniel,

I am opening this PR to propose minimalistic working documentation for your package. With the files as they are in `docs` you should have no problems uploading to [readthedocs](https://readthedocs.org). In case you have any issues, let me know :)

P.S.: the solution to importing pywin32 in the readthedocs was quite simple. Instead of importing `import win32com.client as win32`  in the scope of the `flowsheet.py` file, you can import inside the `Simulation` class. I tested the modification here, but you may want to test it more. Having unit tests would be nice for this package.

Kind regards,
Lucas.