### PR TITLE
Add error handling in EnergyStream @ PFR

### DIFF
--- a/pysis/flowsheet.py
+++ b/pysis/flowsheet.py
@@ -596,7 +596,10 @@ class PFR(ProcessUnit):
         """        
         feed = [i.name for i in self.COMObject.Feeds]
         product = self.COMObject.Product.name
-        energy  = self.COMObject.EnergyStream.name
+        try:
+            energy = self.COMObject.EnergyStream.name
+        except:
+            energy = None
         return {"Feed": feed, "Product": product, "EnergyStream": energy}
     
     def modify_feed(self, stream_group: list, movement: str) -> None:


### PR DESCRIPTION
Hola Daniel, qué tal?

A student of mine was having trouble instantiating the PySIS's `Simulation` class. I went in to find what was off, and it turns out that the `Simulation` instantiation crashes if there's an adiabatic PFR without an energy stream connected. Aspen HYSYS accepts having an energy stream with zero energy flow or no energy stream at all in adiabatic PRFs. The same behavior might be true for adiabatic flash separators. The only thing I changed in the codebase was adding an error handling in the `PFR` class so that its `get_connections()` method tries to get `energy` in case there is one, otherwise it stores `None`.

I tested here and the new piece of code is working as expected. In case you think this small modification makes sense, you may consider reviewing this PR.

Un saludo,
Lucas.